### PR TITLE
[CI] Update path to find gradlew

### DIFF
--- a/.github/workflows/android-lint.yml
+++ b/.github/workflows/android-lint.yml
@@ -12,8 +12,10 @@ jobs:
       with:
         java-version: '17'
         distribution: 'adopt'
+    - name: Change directory to where gradlew is
+      run: cd swpp-2023-project-team-12/android/RunUsAndroid/
     - name: Set execute permissions for gradlew
-      run: chmod +x ./gradlew
+      run: chmod +x gradlew
     - name: Run Android Linter
       run: ./gradlew lintDebug
     - name: Run Checkstyle


### PR DESCRIPTION
- android-lint 파일에서 gradlew 찾는 경로 변경
- root directory는 swpp-... 인데 gradlew 파일은 swpp-2023-project-team-12/android/RunUsAndroid/에 있어서 경로를 찾지 못해 CI 터지는 문제 해결