### PR TITLE
fixed:multimode pace only shown under 30

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
@@ -231,15 +231,33 @@ public class MultiModePlayFragment extends Fragment {
                             // unit : meter -> kilometer
                             double last_distance_5s_kilometer = location.distanceTo(lastLocation) / (double) 1000;
                             distance += last_distance_5s_kilometer;
-                            double speed_average = distance / (double) (Duration.between(gameStartTime, LocalDateTime.now()).getSeconds() / 3600.0);
 
-                            if (speed_average > 0.1) {
-                                Log.d("debug:distance", "last 5s distance (km) : " + last_distance_5s_kilometer + "");
-                                Log.d("debug:speed", "average speed since start (km/h) : " + speed_average + "");
-                                String paceString = String.format("%4.2f km/h", speed_average);
-                                pacePresentContentTextView.setText(paceString);
+                            // double speed_average = distance / (double) (Duration.between(gameStartTime, LocalDateTime.now()).getSeconds() / 3600.0);
+
+//                            if (speed_average > 0.1) {
+//                                Log.d("debug:distance", "last 5s distance (km) : " + last_distance_5s_kilometer + "");
+//                                Log.d("debug:speed", "average speed since start (km/h) : " + speed_average + "");
+//                                String paceString = String.format("%4.2f km/h", speed_average);
+//                                pacePresentContentTextView.setText(paceString);
+//                            } else {
+//                                String paceString = "--.-- km/h";
+//                                pacePresentContentTextView.setText(paceString);
+//                            }
+
+                            if (last_distance_5s_kilometer != 0 ) {
+                                int paceMinute = (int) (1 / (last_distance_5s_kilometer / 5)) / 60;
+                                int paceSecond = (int) (1 / (last_distance_5s_kilometer / 5)) % 60;
+
+                                if (paceMinute <= 30) {
+                                    String paceString = String.format("%02d'%02d\"", paceMinute, paceSecond);
+                                    pacePresentContentTextView.setText(paceString);
+                                }
+                                else {
+                                    String paceString = "--'--\"";
+                                    pacePresentContentTextView.setText(paceString);
+                                }
                             } else {
-                                String paceString = "--.-- km/h";
+                                String paceString = "--'--\"";
                                 pacePresentContentTextView.setText(paceString);
                             }
 

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/SocketManager.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/SocketManager.java
@@ -25,8 +25,8 @@ public class SocketManager { // 모든 fragment에서 공통의 소켓을 활용
 
     public void openSocket() throws IOException { //소켓 열기
         if (socket == null || socket.isClosed()) {
-            socket = new Socket("192.168.0.4", 5001);
-            //socket = new Socket("ec2-3-36-116-64.ap-northeast-2.compute.amazonaws.com", 5001);
+            //socket = new Socket("192.168.0.4", 5001);
+            socket = new Socket("ec2-3-36-116-64.ap-northeast-2.compute.amazonaws.com", 5001);
             System.out.println("open socket");
 
             oos = new ObjectOutputStream(socket.getOutputStream()); //서버로 보내는 바이트스트림을 직렬화 하기 위해 사용

--- a/android/RunUsAndroid/app/src/main/res/layout/fragment_multi_room_play.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/fragment_multi_room_play.xml
@@ -31,7 +31,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/pretendardregular"
                 android:gravity="center_horizontal"
-                android:text="평균 속력"
+                android:text="현재 페이스"
                 android:textAppearance="@style/multi_room_play_goal" />
 
             <TextView
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/pretendardregular"
                 android:gravity="center_horizontal"
-                android:text="--:-- km/h"
+                android:text="--'--''"
                 android:textAppearance="@style/multi_room_play_goal" />
         </LinearLayout>
 

--- a/android/RunUsAndroid/app/src/main/res/layout/fragment_multi_room_play.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/fragment_multi_room_play.xml
@@ -31,7 +31,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/pretendardregular"
                 android:gravity="center_horizontal"
-                android:text="현재 페이스"
+                android:text="평균 속력"
                 android:textAppearance="@style/multi_room_play_goal" />
 
             <TextView
@@ -40,7 +40,7 @@
                 android:layout_height="wrap_content"
                 android:fontFamily="@font/pretendardregular"
                 android:gravity="center_horizontal"
-                android:text="--:--"
+                android:text="--:-- km/h"
                 android:textAppearance="@style/multi_room_play_goal" />
         </LinearLayout>
 


### PR DESCRIPTION
### PR Title: [Descriptive title summarizing the change]
#### Related Issue(s):
멀티모드에서 플레이 중 현재 페이스가 (특히 멈춰있을 때) 큰 값으로 튀는 현상 
#### PR Description:
~~임시로 pace는 평균 km/h로 표시되게 하였으나 추후 수정 가능합니다~~
지난 5초간의 순간 pace로 표시되며, `30'59"` 초과시 표시되지 않습니다 (`--'--"` 로 표시됩니다)
##### Changes Included:
- [ ] Added new feature(s)
- [ v ] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
