### PR TITLE
Fix: FileLogger added, Speedlist deleted (unused), enlarged modal exit button, added dummy profile

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/Logging/FileLogger.java
+++ b/android/RunUsAndroid/app/src/main/java/Logging/FileLogger.java
@@ -1,0 +1,32 @@
+package Logging;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+// save log to file in device
+// you can find log file in directory returned by context.getFilesDir()
+// you can navigate in folders of device in Android Studio -> View -> Tool Windows -> Device Explorer
+// context.getFilesDir() returns path "/data/data/com.example.runusandroid/files/phenotype_storage_info"
+
+public class FileLogger {
+
+    public static void logToFileAndLogcat(Context context, String tag, String message) {
+        // Log to Logcat
+        Log.d(tag, message);
+
+        // Log to a file
+        try {
+            File logFile = new File(context.getFilesDir(), "distance_log.txt");
+            FileOutputStream outputStream = new FileOutputStream(logFile, true);
+            String logMessage = message + "\n";
+            outputStream.write(logMessage.getBytes());
+            outputStream.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -67,6 +67,7 @@ import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
+import Logging.FileLogger;
 
 public class SingleModeFragment extends Fragment {
 
@@ -661,20 +662,24 @@ public class SingleModeFragment extends Fragment {
                             lastLocation.setLongitude(pathPoints.get(pathPoints.size() - 2).longitude);
                             // unit : meter -> kilometer
                             distance += location.distanceTo(lastLocation) / (double) 1000;
-                            if ((int) distance != lastDistanceInt) {
-                                LocalDateTime currentTime = LocalDateTime.now();
-                                Duration iterationDuration = Duration.between(iterationStartTime, currentTime);
-                                long secondsDuration = iterationDuration.getSeconds();
-                                float newPace = (float) (1.0 / (secondsDuration / 3600.0));
-                                if (newPace > maxSpeed)
-                                    maxSpeed = newPace;
-                                if (newPace < minSpeed)
-                                    minSpeed = newPace;
-                                speedList.add(newPace);
-                                iterationStartTime = currentTime;
-
-                            }
-                            Log.d("test:distance", "Distance:" + distance);
+                            Log.d("test:distance:5sec", "Last 5 second Distance :" + location.distanceTo(lastLocation) / (double) 1000);
+                            // log distance into file
+                            FileLogger.logToFileAndLogcat(mainActivity, "test:distance:5sec", ""+location.distanceTo(lastLocation) / (double) 1000);
+                            // Below code seems to cause NullPointerException after 10 minutes or so (on Duration.between)
+//                            if ((int) distance != lastDistanceInt) {
+//                                LocalDateTime currentTime = LocalDateTime.now();
+//                                Duration iterationDuration = Duration.between(iterationStartTime, currentTime);
+//                                long secondsDuration = iterationDuration.getSeconds();
+//                                float newPace = (float) (1.0 / (secondsDuration / 3600.0));
+//                                if (newPace > maxSpeed)
+//                                    maxSpeed = newPace;
+//                                if (newPace < minSpeed)
+//                                    minSpeed = newPace;
+//                                speedList.add(newPace);
+//                                iterationStartTime = currentTime;
+//
+//                            }
+                            Log.d("test:distance:total", "Distance:" + distance);
                         }
                     }
                     currentDistanceText.setText(String.format(Locale.getDefault(), "%.2f " + "km", distance));

--- a/android/RunUsAndroid/app/src/main/res/drawable/circle_profile_picture.xml
+++ b/android/RunUsAndroid/app/src/main/res/drawable/circle_profile_picture.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+    <shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#CCCCCC" />
+    <size android:width="120dp" android:height="120dp" />
+</shape>

--- a/android/RunUsAndroid/app/src/main/res/layout/create_room_modal_layout.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/create_room_modal_layout.xml
@@ -17,6 +17,7 @@
             android:layout_alignParentEnd="true"
             android:layout_marginTop="10dp"
             android:layout_marginEnd="10dp"
+            android:padding="10dp"
             android:background="@android:color/transparent"
             android:src="@drawable/ic_close" />
         <!-- 그룹명 -->

--- a/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
@@ -6,6 +6,28 @@
     android:layout_height="match_parent"
     tools:context=".ui.user_setting.UserSettingFragment">
 
+    <ImageView
+        android:id="@+id/profile_picture_bg"
+        android:layout_width="100dp"
+        android:layout_height="100dp"
+        android:background="@drawable/circle_profile_picture"
+        android:scaleType="center"
+        app:layout_constraintBottom_toTopOf="@+id/LogoutBtn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/profile_picture"
+        android:layout_width="70dp"
+        android:layout_height="70dp"
+        android:scaleType="fitCenter"
+        app:layout_constraintBottom_toTopOf="@+id/LogoutBtn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/single_mode" />
+
     <TextView
         android:id="@+id/text_user_setting"
         android:layout_width="match_parent"


### PR DESCRIPTION
### PR Title: FileLogger added, Speedlist deleted (unused), enlarged modal exit button, added dummy profile
#### Related Issue(s):
앱 싱글모드 플레이 시 시간이 10분 이상 지나면 강제 종료되는 현상
room create 시 x버튼이 작아서 잘 눌리지 않고 사용성이 떨어지는 현상
#### PR Description:
FileLogger added to check distance on still state
Speedlist deleted due to error on long duration singlemode play (usused for now), checked history save still works well 
enlarged modal exit button on multimode room create
added dummy profile
##### Changes Included:
- [v ] Added new feature(s)
- [v ] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
