### PR TITLE
activity recognition improved, applyed on single mode

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ActivityRecognition/UserActivityBroadcastReceiver.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ActivityRecognition/UserActivityBroadcastReceiver.java
@@ -14,7 +14,10 @@ import java.util.Objects;
 
 public class UserActivityBroadcastReceiver extends BroadcastReceiver {
 
-    boolean isRunning = true;
+    boolean isRunning = false;
+    String lastActivityType = "DEFAULT";
+    String lastTransitionType = "DEFAULT";
+
     @Override
     public void onReceive(Context context, Intent intent) {
         if (!Objects.equals(intent.getAction(), UserActivityTransitionManager.CUSTOM_INTENT_USER_ACTION)) {
@@ -23,20 +26,18 @@ public class UserActivityBroadcastReceiver extends BroadcastReceiver {
         if (ActivityTransitionResult.hasResult(intent)) {
             ActivityTransitionResult result = ActivityTransitionResult.extractResult(intent);
             for (ActivityTransitionEvent event : result.getTransitionEvents()) {
-                String activityType;
-                String transitionType;
 
-                if (event.getActivityType() == DetectedActivity.WALKING) activityType = "WALKING";
-                else if (event.getActivityType() == DetectedActivity.RUNNING) activityType = "RUNNING";
-                else if (event.getActivityType() == DetectedActivity.STILL) activityType = "STILL";
-                else activityType = "illegal";
+                if (event.getActivityType() == DetectedActivity.WALKING) lastActivityType = "WALKING";
+                else if (event.getActivityType() == DetectedActivity.RUNNING) lastActivityType = "RUNNING";
+                else if (event.getActivityType() == DetectedActivity.STILL) lastActivityType = "STILL";
+                else lastActivityType = "illegal";
 
-                if(event.getTransitionType() == ActivityTransition.ACTIVITY_TRANSITION_ENTER) transitionType = "ENTER";
-                else if(event.getTransitionType() == ActivityTransition.ACTIVITY_TRANSITION_EXIT) transitionType = "EXIT";
-                else transitionType = "illegal";
+                if(event.getTransitionType() == ActivityTransition.ACTIVITY_TRANSITION_ENTER) lastTransitionType = "ENTER";
+                else if(event.getTransitionType() == ActivityTransition.ACTIVITY_TRANSITION_EXIT) lastTransitionType = "EXIT";
+                else lastTransitionType = "illegal";
 
-                Toast.makeText(context, "activity detected, " + transitionType+ " " + activityType, Toast.LENGTH_LONG).show();
-                saveState(activityType, transitionType);
+                Toast.makeText(context, "activity detected, " + lastTransitionType+ " " + lastActivityType, Toast.LENGTH_LONG).show();
+                saveState(lastActivityType, lastTransitionType);
             }
         }
     }
@@ -46,8 +47,17 @@ public class UserActivityBroadcastReceiver extends BroadcastReceiver {
         if(activityType == "RUNNING" && transitionType == "ENTER") {
             isRunning = true;
         }
+        else if(activityType == "RUNNING" && transitionType == "EXIT") {
+            isRunning = false;
+        }
         else if(activityType == "WALKING" && transitionType == "ENTER") {
             isRunning = true;
+        }
+        else if(activityType == "WALKING" && transitionType == "EXIT") {
+            isRunning = false;
+        }
+        else if(activityType == "STILL" && transitionType == "ENTER") {
+            isRunning = false;
         }
         else {
             isRunning = false;
@@ -56,5 +66,11 @@ public class UserActivityBroadcastReceiver extends BroadcastReceiver {
 
     public boolean getIsRunning() {
         return isRunning;
+    }
+    public String getLastActivityType() {
+        return lastActivityType;
+    }
+    public String getLastTransitionType() {
+        return lastTransitionType;
     }
 }

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -654,7 +654,7 @@ public class SingleModeFragment extends Fragment {
                     }
 
                     // get distance
-                    if (newPoint != null) {
+                    if (newPoint != null && mainActivity.activityReceiver.getIsRunning()) {
                         // first few points might be noisy
                         if (pathPoints.size() > 5) {
                             Location lastLocation = new Location("");

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/user_setting/UserSettingFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/user_setting/UserSettingFragment.java
@@ -9,6 +9,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatButton;
@@ -16,12 +17,14 @@ import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 
 import com.example.runusandroid.LoginActivity;
+import com.example.runusandroid.MainActivity2;
 import com.example.runusandroid.R;
 import com.example.runusandroid.databinding.FragmentUserSettingBinding;
 
 public class UserSettingFragment extends Fragment {
 
     private FragmentUserSettingBinding binding;
+    MainActivity2 mainActivity;
 
     public View onCreateView(@NonNull LayoutInflater inflater,
                              ViewGroup container, Bundle savedInstanceState) {
@@ -31,6 +34,7 @@ public class UserSettingFragment extends Fragment {
         String userName = sharedPreferences.getString("username", "");
         binding = FragmentUserSettingBinding.inflate(inflater, container, false);
         View root = binding.getRoot();
+        mainActivity = (MainActivity2) getActivity();
 
         final TextView textView = binding.textUserSetting;
         userSettingViewModel.setText(userName + "님 환영해요!");
@@ -43,6 +47,23 @@ public class UserSettingFragment extends Fragment {
             public void onClick(View v) {
                 logoutUser();
             }
+        });
+
+        // TO CHECK ACTIVITY STATE
+        AppCompatButton checkButton = root.findViewById(R.id.check);
+        checkButton.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+
+                String activityType = mainActivity.activityReceiver.getLastActivityType();
+                String transitionType = mainActivity.activityReceiver.getLastTransitionType();
+                boolean isRunning = mainActivity.activityReceiver.getIsRunning();
+
+                Toast.makeText(mainActivity, "last state:" + transitionType+ " " + activityType + " " + isRunning, Toast.LENGTH_LONG).show();
+
+            }
+
         });
 
         return root;

--- a/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
@@ -54,4 +54,13 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@id/text_user_setting" />
 
+    <Button
+        android:id="@+id/check"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:backgroundTint="#FFFFFF"
+        android:text="check"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### PR Title: [Descriptive title summarizing the change]
#### Related Issue(s):
Activity recognition 안정성이 떨어지는문제
#### PR Description:
BackgroundActivityReceiver 코드 수정 
-> 작동 확인돼서 싱글모드에 적용
유저세팅 오른쪽하단에 히든버튼이 있습니다 (누르면 마지막으로 관측된 activity type, transition type, isRunning 값이 토스트로 띄워집니다 (현재 isRunning이 True일 시에만 싱글모드와 멀티모드에서 distance에 더해집니다) 
##### Changes Included:
- [ ] Added new feature(s)
- [v] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
