### PR TITLE
Fix: 프로필사진 관련 버그 수정

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/AccountApi.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/AccountApi.java
@@ -4,9 +4,11 @@ import okhttp3.MultipartBody;
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.GET;
 import retrofit2.http.Multipart;
 import retrofit2.http.POST;
 import retrofit2.http.Part;
+import retrofit2.http.Path;
 
 public interface AccountApi {
     @POST("/account/signup/")
@@ -24,4 +26,7 @@ public interface AccountApi {
     @Multipart
     @POST("/account/profile_image/")
     Call<ImageResponse> uploadProfileImage(@Part MultipartBody.Part file);
+
+    @GET("/account/user_profile/{user_id}/")
+    Call<UserProfileResponse> getUserProfile(@Path("user_id") String userId);
 }

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/UserProfileResponse.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/UserProfileResponse.java
@@ -1,0 +1,13 @@
+package com.example.runusandroid;
+
+import com.google.gson.annotations.SerializedName;
+
+public class UserProfileResponse {
+    private String username;
+    @SerializedName("profile_image_url")
+    private String profileImageUrl;
+
+    public String getProfileImageUrl() {
+        return profileImageUrl;
+    }
+}

--- a/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/fragment_user_setting.xml
@@ -29,10 +29,11 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/UserSettingTitle" />
 
-    <de.hdodenhof.circleimageview.CircleImageView
+    <ImageView
         android:id="@+id/profileImage"
         android:layout_width="150dp"
         android:layout_height="150dp"
+        android:src="@drawable/profile_image_for_multi"
         app:layout_constraintBottom_toTopOf="@+id/changeProfileImageButton"
         app:layout_constraintStart_toStartOf="@id/TextUserName"
         app:layout_constraintTop_toBottomOf="@id/TextUserName" />

--- a/django/account/serializers.py
+++ b/django/account/serializers.py
@@ -86,3 +86,17 @@ class EmailSerializer(serializers.Serializer):
 class ResetPasswordSerializer(serializers.Serializer):
     username = serializers.CharField(required=True)
     email = serializers.EmailField(required=True)
+
+
+class UserProfileSerializer(serializers.ModelSerializer):
+    profile_image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CustomUser
+        fields = ["username", "profile_image_url"]
+
+    def get_profile_image_url(self, obj):
+        request = self.context.get("request")
+        if obj.profile_image and hasattr(obj.profile_image, "url"):
+            return request.build_absolute_uri(obj.profile_image.url)
+        return None

--- a/django/account/urls.py
+++ b/django/account/urls.py
@@ -5,6 +5,7 @@ from .views import (
     ResetPasswordView,
     SignupView,
     LoginView,
+    UserProfileView,
 )
 from . import views
 
@@ -19,4 +20,9 @@ urlpatterns = [
     ),
     path("reset_password/", ResetPasswordView.as_view(), name="reset_password"),
     path("profile_image/", ProfileImageView.as_view(), name="profile_image"),
+    path(
+        "user_profile/<int:user_id>/",
+        UserProfileView.as_view(),
+        name="user_profile",
+    ),
 ]

--- a/django/account/views.py
+++ b/django/account/views.py
@@ -3,12 +3,14 @@ import secrets
 import string
 from venv import logger
 from django.conf import settings
+from django.shortcuts import get_object_or_404
 from account.models import CustomUser
 from .serializers import (
     EmailSerializer,
     ResetPasswordSerializer,
     UserCreateSerializer,
     LoginSerializer,
+    UserProfileSerializer,
 )
 from rest_framework.response import Response
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
@@ -20,7 +22,6 @@ from django.core.mail import send_mail
 from django.db import transaction
 from rest_framework.parsers import MultiPartParser, FormParser
 from .serializers import UserProfileImageSerializer
-from django.core.files.storage import default_storage
 
 
 # Create your views here.
@@ -46,9 +47,7 @@ class LoginView(APIView):
         refresh_token = str(token)
         access_token = str(token.access_token)
         if user.profile_image and user.profile_image.name:
-            profile_image_url = (
-                settings.MEDIA_URL + "profile_images/" + user.profile_image.name
-            )
+            profile_image_url = settings.MEDIA_URL + user.profile_image.name
         else:
             profile_image_url = settings.MEDIA_URL + "temp_profile.jpeg"
         response = Response(

--- a/django/account/views.py
+++ b/django/account/views.py
@@ -164,3 +164,13 @@ class ProfileImageView(APIView):
         else:
             logger.error(f"Serializer errors: {serializer.errors}")
             return Response(serializer.errors, status=400)
+
+
+class UserProfileView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, user_id=None):
+        user = get_object_or_404(CustomUser, id=user_id) if user_id else request.user
+        logger.debug(f"send profile url: {user.profile_image.url}")
+        serializer = UserProfileSerializer(user, context={"request": request})
+        return Response(serializer.data)

--- a/django/runusDjango/settings.py
+++ b/django/runusDjango/settings.py
@@ -186,8 +186,7 @@ EMAIL_HOST = "smtp.gmail.com"
 EMAIL_USE_TLS = True
 EMAIL_PORT = 587
 EMAIL_HOST_USER = "runusnoreply"
-EMAIL_HOST_PASSWORD = "uowq tlzw ckdo ehml"  # 실제 Gmail 비밀번호 입력
-
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
 MEDIA_ROOT = BASE_DIR / "media"
 MEDIA_URL = "/media/"
 STATIC_URL = "static/"


### PR DESCRIPTION
## PR Title: 프로필사진 관련 버그 수정
### PR Description:
#### 문제
- 로그아웃 -> 로그인했을 때 프로필 이미지를 찾지 못하는 문제가 있었음
#### 디버깅
- 장고에서 경로 설정할 때 profile_image를 중복으로 설정하고 있어(path=../profile_image/profile_image/..) 수정했으나 문제 해결되지 않음
- 프로필 이미지로 같은 이름을 사용했을 때 캐시 문제가 발생하여 이미지가 업데이트 안되는 문제를 해결하기 위해 캐시를 무효화할 수 있는 쿼리 파라미터 ?v={random_number}를 넣었음. 정확히 분석하진 않았는데 아마 쿼리 파라미터 때문에 정확한 경로를 찾지 못하는 문제로 예상됨
#### 해결
- 프로필 이미지 path를 쿼리하는 API를 추가로 도입함
#### 수정 사항
1. settings.py에서 관리하던 이메일 비밀번호를 환경변수로 관리
2. 로그아웃 -> 로그인 후 프로필 이미지 렌더링 안되는 문제 해결
3. 로그아웃 -> 로그인 후 멀티모드 룸 리스트에서 방장 이미지 렌더링 안되는 문제 해결
4. 프로필 이미지에 디폴트 이미지 추가 (로고)
   - 사진 못찾는 경우가 생겨도 로고 렌더링해서 전혀 어색하지 않음
##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
카톡으로 뿌린 환경변수 설정해야 이메일 보낼 수 있음. (로컬이면 로컬에 + 서버는 서버에서)
