### PR TITLE
Fix singlemode distance precision

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -206,7 +206,7 @@ public class SingleModeFragment extends Fragment {
                             Log.d("test:distance:total", "Distance:" + distance);
                         }
                     }
-                    currentDistanceText.setText(String.format(Locale.getDefault(), "%.1f " + "km", distance));
+                    currentDistanceText.setText(String.format(Locale.getDefault(), "%.1f " + "km", Math.floor(distance * 10) / 10));
 
                     lastLocation = location;
 

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -206,7 +206,7 @@ public class SingleModeFragment extends Fragment {
                             Log.d("test:distance:total", "Distance:" + distance);
                         }
                     }
-                    currentDistanceText.setText(String.format(Locale.getDefault(), "%.2f " + "km", distance));
+                    currentDistanceText.setText(String.format(Locale.getDefault(), "%.1f " + "km", distance));
 
                     lastLocation = location;
 
@@ -797,7 +797,7 @@ public class SingleModeFragment extends Fragment {
         lastLocation = null;
         distance = 0;
         currentPace.setVisibility(View.VISIBLE);
-        currentDistanceText.setText("0.00 km");
+        currentDistanceText.setText("0.0 km");
         runningNow = true;
         currentTimeText.setOnChronometerTickListener(new Chronometer.OnChronometerTickListener() {
             public void onChronometerTick(Chronometer chronometer) {
@@ -1163,7 +1163,7 @@ public class SingleModeFragment extends Fragment {
                 goalTimeText.setText("");
                 lastLocation = null;
                 distance = 0;
-                currentDistanceText.setText("0.00 km");
+                currentDistanceText.setText("0.0 km");
                 currentTimeText.setBase(SystemClock.elapsedRealtime());
             }
         });

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeResultFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeResultFragment.java
@@ -47,6 +47,7 @@ import com.google.android.gms.maps.model.PolylineOptions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 public class SingleModeResultFragment extends Fragment {
@@ -230,7 +231,7 @@ public class SingleModeResultFragment extends Fragment {
         requireActivity().getOnBackPressedDispatcher().addCallback(this, backPressedCallBack);
 
         goalDistanceText.setText(floatToFirstDeciStr(goalDistance) + "km");
-        currentDistanceText.setText(doubleToFirstDeciStr(currentDistance) + "km");
+        currentDistanceText.setText(String.format(Locale.getDefault(), "%.1f " + "km", Math.floor(currentDistance * 10) / 10));
         goalTimeText.setText(goalTime + " 분");
         currentTimeText.setText(dateFormat.format(currentTime));
         if (isMapReady) {

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeResultFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeResultFragment.java
@@ -230,7 +230,7 @@ public class SingleModeResultFragment extends Fragment {
         requireActivity().getOnBackPressedDispatcher().addCallback(this, backPressedCallBack);
 
         goalDistanceText.setText(floatToFirstDeciStr(goalDistance) + "km");
-        currentDistanceText.setText(doubleToThirdDeciStr(currentDistance) + "km");
+        currentDistanceText.setText(doubleToFirstDeciStr(currentDistance) + "km");
         goalTimeText.setText(goalTime + " 분");
         currentTimeText.setText(dateFormat.format(currentTime));
         if (isMapReady) {
@@ -255,6 +255,11 @@ public class SingleModeResultFragment extends Fragment {
 
     private String doubleToThirdDeciStr(double num) {
         DecimalFormat decimalFormat = new DecimalFormat("#.###");
+        return decimalFormat.format(num);
+    }
+
+    private String doubleToFirstDeciStr(double num) {
+        DecimalFormat decimalFormat = new DecimalFormat("#.#");
         return decimalFormat.format(num);
     }
 


### PR DESCRIPTION
### PR Title: Fix singlemode distance precision
#### Related Issue(s):
fix: singlemode play, result distance precision to #.# format (floor function)
싱글모드 플레이중, 결과 화면에서 소수점 자리수 통일되지 않음
#### PR Description:
소수점 아래 한자리수까지 표시하는걸로 통일 (소수점 아래 두자리수부터 버림)
##### Changes Included:
- [ ] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
