### PR TITLE
Fix: resize map scale & single mode's dialog showing time

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
@@ -158,7 +158,7 @@ public class MultiModePlayFragment extends Fragment {
                     mMap.clear(); // Remove previous polylines
                     mMap.addPolyline(new PolylineOptions().addAll(pathPoints).color(Color.parseColor("#4AA570")).width(10));
                     if (newPoint != null) {
-                        mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 20));
+                        mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 15));
                     }
                 }
 

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -161,7 +161,7 @@ public class SingleModeFragment extends Fragment {
                         mMap.clear(); // Remove previous polylines
                         mMap.addPolyline(new PolylineOptions().addAll(pathPoints).color(Color.parseColor("#4AA570")).width(10));
                         if (newPoint != null) {
-                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 20));
+                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 16));
                         }
                     }
 
@@ -230,7 +230,7 @@ public class SingleModeFragment extends Fragment {
                     if (mMap != null) {
                         mMap.clear(); // Remove previous polylines
                         if (newPoint != null) {
-                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 16));
+                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 15));
                         }
                     }
                 }
@@ -825,18 +825,18 @@ public class SingleModeFragment extends Fragment {
         distance = 0;
         currentPace.setVisibility(View.VISIBLE);
         currentDistanceText.setText("0.0 km");
-        runningNow = true;
         currentTimeText.setOnChronometerTickListener(new Chronometer.OnChronometerTickListener() {
             public void onChronometerTick(Chronometer chronometer) {
                 currentTime = SystemClock.elapsedRealtime() - chronometer.getBase();
                 chronometer.setText(dateFormat.format(currentTime));
             }
         });
+        hideBottomNavigation(true);
         currentTimeText.setBase(SystemClock.elapsedRealtime());
         currentTimeText.start();
         startButton.setVisibility(View.GONE);
         quitButton.setVisibility(View.VISIBLE);
-        hideBottomNavigation(true);
+        runningNow = true;
     }
 
     private void setTextBold(TextView wantView, String[] words) {

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -161,7 +161,7 @@ public class SingleModeFragment extends Fragment {
                         mMap.clear(); // Remove previous polylines
                         mMap.addPolyline(new PolylineOptions().addAll(pathPoints).color(Color.parseColor("#4AA570")).width(10));
                         if (newPoint != null) {
-                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 16));
+                            mMap.animateCamera(CameraUpdateFactory.newLatLngZoom(newPoint, 15));
                         }
                     }
 


### PR DESCRIPTION
### PR Title: Fix: resize map scale & single mode's dialog showing time
#### Related Issue(s):
맵 사이즈 이슈
#### PR Description:
두 모드에서 맵 사이즈를 일단 15까지 낮췄고,
싱글 모드에서 running 시작이 다른 로직이 다 처리되고 나서 되는 게 나을 것 같아 runningNow 표기를 뒤로 늦췄습니다.
맵 스케일이 더 작은 게 좋으시면 말씀 주세요!
##### Changes Included:
- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
- [V] Minor Update
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
