### PR TITLE
fix: map initial location

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/MainActivity2.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/MainActivity2.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.location.Location;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -48,6 +49,7 @@ public class MainActivity2 extends AppCompatActivity {
     private ActivityMain2Binding binding;
     private FusedLocationProviderClient fusedLocationClient;
     private PermissionSupport permission;
+    public Location initialLocation;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -119,6 +121,7 @@ public class MainActivity2 extends AppCompatActivity {
 
             }).start();
         }
+        getLastLocation();
     }
 
     @Override
@@ -161,6 +164,7 @@ public class MainActivity2 extends AppCompatActivity {
             } else {
                 Log.d("test:location:main", "Location failed");
             }
+            initialLocation = location;
         });
     }
 
@@ -196,12 +200,12 @@ public class MainActivity2 extends AppCompatActivity {
         // 권한이 전부 있다면 정상적으로 진행
         if (permission.checkPermission()) {
             Log.d("test:permission", "allPermissionGranted");
-            // 다시 permission 요청
             createNotificationChannel();
             activityManager.removeActivityTransitions(pendingIntent);
             this.unregisterReceiver(activityReceiver);
             this.registerReceiver(activityReceiver, filter, RECEIVER_EXPORTED);
             activityManager.registerActivityTransitions(pendingIntent);
+            getLastLocation();
         } else if (ActivityCompat.shouldShowRequestPermissionRationale(
                 this, Manifest.permission.ACTIVITY_RECOGNITION)) {
             Log.d("test:permission", "showRationaleActivityRecognition");

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModePlayFragment.java
@@ -344,6 +344,14 @@ public class MultiModePlayFragment extends Fragment {
                         Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
                     mMap.setMyLocationEnabled(true);
                 }
+                // set initial point to on saved already in mainActivity, if null, set to default location (남산타워)
+                LatLng initialPoint;
+                if (mainActivity.initialLocation != null) {
+                    initialPoint = new LatLng(mainActivity.initialLocation.getLatitude(), mainActivity.initialLocation.getLongitude());
+                } else{
+                    initialPoint = new LatLng(37.55225, 126.9873);
+                }
+                mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(initialPoint, 14));
             });
         }
 

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -18,6 +18,7 @@ import android.icu.text.SimpleDateFormat;
 import android.icu.util.TimeZone;
 import android.location.Location;
 import android.os.Bundle;
+import android.os.Looper;
 import android.os.SystemClock;
 import android.text.Editable;
 import android.text.Spannable;
@@ -56,6 +57,9 @@ import com.example.runusandroid.MainActivity2;
 import com.example.runusandroid.R;
 import com.example.runusandroid.RetrofitClient;
 import com.example.runusandroid.databinding.FragmentSingleModeBinding;
+import com.google.android.gms.location.LocationCallback;
+import com.google.android.gms.location.LocationRequest;
+import com.google.android.gms.location.LocationResult;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.SupportMapFragment;
@@ -342,7 +346,17 @@ public class SingleModeFragment extends Fragment {
                     Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
                 mMap.setMyLocationEnabled(true);
             }
+            // set initial point to on saved already in mainActivity, if null, set to default location (남산타워)
+            LatLng initialPoint;
+            if (mainActivity.initialLocation != null) {
+                initialPoint = new LatLng(mainActivity.initialLocation.getLatitude(), mainActivity.initialLocation.getLongitude());
+            } else{
+                initialPoint = new LatLng(37.55225, 126.9873);
+            }
+            mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(initialPoint, 14));
         });
+//        Location initialLocation = mainActivity.getFusedLocationClient().getLastLocation().getResult();
+//        LatLng initialPoint = new LatLng(initialLocation.getLatitude(), initialLocation.getLongitude());
 
         // Viewmodel contains status, and when status changes (observe), the text will
         // change


### PR DESCRIPTION
### PR Title: fix: map initial location
#### Related Issue(s):
싱글모드 진입, 멀티모드 게임화면 진입시 initial location이 아프리카로 보여지는 문제
#### PR Description:
set initial point to one saved already in mainActivity, if null, set to default location (남산타워) with 적당한 zoom
##### Changes Included:
- [x] Added new feature(s)
- [x] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
