### PR TITLE
Fix: Reslove profile image cache problem in ec2 and physical device

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModeResultFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModeResultFragment.java
@@ -226,6 +226,7 @@ public class MultiModeResultFragment extends Fragment {
                 public void onResponse(Call<UserProfileResponse> call, Response<UserProfileResponse> response) {
                     if (response.isSuccessful() && response.body() != null) {
                         String imageUrl = response.body().getProfileImageUrl();
+                        imageUrl = imageUrl + "?timestamp=" + System.currentTimeMillis();
                         Glide.with(MultiModeResultFragment.this)
                                 .load(imageUrl).placeholder(R.drawable.runus_logo)
                                 .apply(RequestOptions.circleCropTransform())
@@ -255,6 +256,7 @@ public class MultiModeResultFragment extends Fragment {
                     public void onResponse(Call<UserProfileResponse> call, Response<UserProfileResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             String imageUrl = response.body().getProfileImageUrl();
+                            imageUrl = imageUrl + "?timestamp=" + System.currentTimeMillis();
                             Glide.with(MultiModeResultFragment.this)
                                     .load(imageUrl).placeholder(R.drawable.runus_logo)
                                     .apply(RequestOptions.circleCropTransform())
@@ -284,6 +286,7 @@ public class MultiModeResultFragment extends Fragment {
                         public void onResponse(Call<UserProfileResponse> call, Response<UserProfileResponse> response) {
                             if (response.isSuccessful() && response.body() != null) {
                                 String imageUrl = response.body().getProfileImageUrl();
+                                imageUrl = imageUrl + "?timestamp=" + System.currentTimeMillis();
                                 Glide.with(MultiModeResultFragment.this)
                                         .load(imageUrl).placeholder(R.drawable.runus_logo)
                                         .apply(RequestOptions.circleCropTransform())

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModeWaitFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/multi_mode/MultiModeWaitFragment.java
@@ -277,6 +277,7 @@ public class MultiModeWaitFragment extends Fragment {
             public void onResponse(Call<UserProfileResponse> call, Response<UserProfileResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {
                     String imageUrl = response.body().getProfileImageUrl();
+                    imageUrl = imageUrl + "?timestamp=" + System.currentTimeMillis();
                     Log.d("prfile", "profile=" + imageUrl);
                     Glide.with(MultiModeWaitFragment.this)
                             .load(imageUrl)

--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/user_setting/UserSettingFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/user_setting/UserSettingFragment.java
@@ -157,18 +157,20 @@ public class UserSettingFragment extends Fragment {
                     Log.d("badgeFromServer", Integer.toString(badgeCollection));
                     editor.apply();
                     String imageUrl = response.body().getProfileImageUrl();
+                    imageUrl = imageUrl + "?timestamp=" + System.currentTimeMillis();
+
                     Log.d("prfile", "profile=" + imageUrl);
-                    if(isVisible() && isAdded()) {
+                    if (isVisible() && isAdded()) {
                         updateProfileImageInView(imageUrl);
-                    }
-                    else{
+                    } else {
                         Log.d("profile", "pass load profile");
                     }
                 } else {
-                    if(isVisible() && isAdded()) {
+                    if (isVisible() && isAdded()) {
                         Glide.with(UserSettingFragment.this)
                                 .load("").placeholder(R.drawable.runus_logo)
                                 .apply(RequestOptions.circleCropTransform())
+                                .skipMemoryCache(true)
                                 .into(profileImageView);
                     }
                 }
@@ -322,6 +324,7 @@ public class UserSettingFragment extends Fragment {
         Glide.with(UserSettingFragment.this)
                 .load(imageUrl).placeholder(R.drawable.runus_logo)
                 .apply(RequestOptions.circleCropTransform())
+                .skipMemoryCache(true)
                 .into(binding.profileImage);
     }
 


### PR DESCRIPTION
ec2, 피지컬 디바이스 환경에서 프로필 사진 파일이 바뀌었음에도 다른 페이지를 갔다오면 계속 기존 이미지가 렌더링 되는 문제가 있었음 백엔드에서는 해시값 이용해서 캐시 무효화 중인데 프론트에서도 timestamp를 imageurl 추가하여 캐시를 무효화 하였음