### PR TITLE
Hotfix: 싱글모드 커스텀모드에서 거리나 시간 입력되지 않았을 시 validation text 보이고 화면 전환 안되도록 수정

### DIFF
--- a/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
+++ b/android/RunUsAndroid/app/src/main/java/com/example/runusandroid/ui/single_mode/SingleModeFragment.java
@@ -431,6 +431,10 @@ public class SingleModeFragment extends Fragment {
     }
 
     private void showCustomDialog() {
+        final boolean[] validationDistance = {true};
+        final boolean[] validationMinute = {true};
+        final boolean[] validationHour = {true};
+
         View dialogView = getLayoutInflater().inflate(R.layout.dialog_mission_custom, null);
         Dialog dialog = new Dialog(getContext());
         dialog.requestWindowFeature(Window.FEATURE_NO_TITLE);
@@ -454,6 +458,8 @@ public class SingleModeFragment extends Fragment {
         EditText textDistance = dialogView.findViewById(R.id.editTextGoalDistance);
         EditText textHour = dialogView.findViewById(R.id.editTextGoalHour);
         EditText textMinute = dialogView.findViewById(R.id.editTextGoalMinute);
+        TextView MissionDistanceValidationText = dialog.findViewById(R.id.MissionDistanceValidationText);
+        TextView MissionTimeValidationText = dialog.findViewById(R.id.MissionTimeValidationText);
 
 
         textDistance.setText(floatTo1stDecimal(goalDistance));
@@ -479,6 +485,7 @@ public class SingleModeFragment extends Fragment {
 
                 if (s != null && !s.toString().equals("")) {
                     try {
+                        validationDistance[0] = true;
                         String distanceText = s.toString();
                         nowGoalDistance = (float) Double.parseDouble(distanceText);
                         if (((int) (nowGoalDistance * 10)) / 10f != nowGoalDistance) {
@@ -493,6 +500,7 @@ public class SingleModeFragment extends Fragment {
                         e.printStackTrace();
                     }
                 } else {
+                    validationDistance[0] = false;
                     int new_distance = 0;
                     nowGoalDistance = new_distance;
                 }
@@ -519,6 +527,7 @@ public class SingleModeFragment extends Fragment {
 
                 if (s != null && !s.toString().equals("")) {
                     try {
+                        validationHour[0] = true;
                         String hourText = s.toString();
                         int newHour = Integer.parseInt(hourText);
                         nowGoalTime = newHour * 60 + Integer.parseInt(textMinute.getText().toString());
@@ -528,6 +537,7 @@ public class SingleModeFragment extends Fragment {
                         e.printStackTrace();
                     }
                 } else {
+                    validationHour[0] = false;
                     int new_time = 0;
                     nowGoalTime = new_time;
                 }
@@ -554,6 +564,7 @@ public class SingleModeFragment extends Fragment {
 
                 if (s != null && !s.toString().equals("")) {
                     try {
+                        validationMinute[0] = true;
                         String minuteText = s.toString();
                         int newMinute = Integer.parseInt(minuteText);
                         if (newMinute > 59) {
@@ -568,6 +579,7 @@ public class SingleModeFragment extends Fragment {
                         e.printStackTrace();
                     }
                 } else {
+                    validationMinute[0] = false;
                     int new_time = 0;
                     nowGoalTime = new_time;
                 }
@@ -589,11 +601,28 @@ public class SingleModeFragment extends Fragment {
 
         buttonConfirm.setOnClickListener(new Button.OnClickListener() {
             public void onClick(View v) {
-                goalDistance = nowGoalDistance;
-                Log.d("goalDistance", goalDistance + "");
-                goalTime = nowGoalTime;
-                dialog.dismiss();
-                setRunningStart();
+                if (validationMinute[0] && validationHour[0]) {
+                    MissionTimeValidationText.setVisibility(View.GONE);
+                }
+                if (validationDistance[0]) {
+                    MissionDistanceValidationText.setVisibility(View.GONE);
+                }
+                if (!(validationMinute[0] && validationHour[0] && validationDistance[0])) {
+                    if (!validationMinute[0] || !validationHour[0]) {
+                        MissionTimeValidationText.setVisibility(View.VISIBLE);
+                    }
+                    if (!validationDistance[0]) {
+                        MissionDistanceValidationText.setVisibility(View.VISIBLE);
+                    }
+                } else {
+                    goalDistance = nowGoalDistance;
+                    Log.d("goalDistance", goalDistance + "");
+                    goalTime = nowGoalTime;
+                    dialog.dismiss();
+                    setRunningStart();
+                }
+
+
             }
         });
 

--- a/android/RunUsAndroid/app/src/main/res/layout/dialog_mission_custom.xml
+++ b/android/RunUsAndroid/app/src/main/res/layout/dialog_mission_custom.xml
@@ -7,7 +7,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="450dp"
         android:layout_marginHorizontal="16dp"
         android:background="@drawable/round_shape_dialog"
         android:padding="16dp">
@@ -17,15 +17,45 @@
             android:id="@+id/textViewMissionInfo2"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_margin="5dp"
+            android:layout_margin="3dp"
             android:gravity="center"
-            android:padding="6dp"
+            android:padding="2dp"
             android:text="* 커스텀 모드의 목표 거리는 km 단위로만 설정할 수 있어요."
             android:textSize="11dp"
             app:layout_constraintBottom_toTopOf="@+id/editTextGoalHour"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/editTextGoalDistance" />
+
+        <TextView
+            android:id="@+id/MissionDistanceValidationText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="3dp"
+            android:gravity="left"
+            android:text="거리를 입력해주세요."
+            android:textColor="#FF0000"
+            android:textSize="11dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@+id/editTextGoalHour"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/guideline1"
+            app:layout_constraintTop_toBottomOf="@+id/textViewMissionInfo2" />
+
+        <TextView
+            android:id="@+id/MissionTimeValidationText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="3dp"
+            android:gravity="left"
+            android:text="시간을 입력해주세요."
+            android:textColor="#FF0000"
+            android:textSize="11dp"
+            android:visibility="gone"
+
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/guideline1"
+            app:layout_constraintTop_toBottomOf="@+id/editTextGoalHour" />
 
         <TextView
             android:id="@+id/textViewMissionInfo3"
@@ -143,7 +173,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/round_shape_light_gray"
             android:gravity="right|center"
-            android:hint="0"
+            android:hint="-"
             android:inputType="numberDecimal"
             android:maxLength="4"
             android:paddingLeft="15dp"
@@ -186,7 +216,7 @@
             android:layout_marginBottom="2dp"
             android:background="@drawable/round_shape_light_gray"
             android:gravity="right|center"
-            android:hint="0"
+            android:hint="-"
             android:inputType="number"
             android:maxLength="2"
             android:paddingLeft="15dp"
@@ -215,7 +245,7 @@
             android:layout_height="wrap_content"
             android:background="@drawable/round_shape_light_gray"
             android:gravity="right|center"
-            android:hint="0"
+            android:hint="-"
             android:inputType="number"
             android:max="59"
             android:maxLength="2"
@@ -250,6 +280,7 @@
             app:layout_constraintHorizontal_weight="0.1"
             app:layout_constraintStart_toEndOf="@+id/editTextGoalDistance"
             app:layout_constraintTop_toBottomOf="@+id/textViewMissionInfo2" />
+
 
         <Button
             android:id="@+id/buttonConfirm"


### PR DESCRIPTION
### PR Title: Hotfix: 싱글모드 커스텀모드에서 거리나 시간 입력되지 않았을 시 validation text 보이고 화면 전환 안되도록 수정
#### Related Issue(s):
기존에는 싱글모드 커스텀 모드에서 거리나 시간을 입력하지 않으면 0으로 자동으로 값이 들어가서 화면 넘어갔음. 
이 것보다 값을 입력하도록 하는 문구를 띄우고 정확한 값을 입력받는 것이 유저 경험에 더 좋을 것 같아 수정.
#### PR Description:
[Provide a brief summary of the changes made.]
##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):
Attach screenshots or GIFs of any visual changes. (Only for
frontend-related changes)
##### Notes for Reviewer:
Any specific instructions or points to be considered by the
reviewer.
---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.
---
#### Additional Comments:
Add any other comments or information that might be useful for the
review process.
